### PR TITLE
✨ variables: add validation rules (closes #31)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -45,24 +45,50 @@ variable "runtime" {
   description = "Runtime environment for the Lambda function (e.g., python3.9, nodejs14.x)"
   type        = string
   nullable    = false
+
+  validation {
+    # Structural (shape) check, NOT a version-locked allow-list: AWS ships new
+    # runtimes constantly (python3.14, nodejs24.x, java25, dotnet10, ...), so an
+    # enumerated regex would reject valid runtimes the day they launch. This
+    # matches the identifier *families* and catches typos (e.g. "node20",
+    # "pyhton3.12") while staying forward-compatible.
+    condition     = can(regex("^(nodejs\\d+\\.x|python\\d+\\.\\d+|java\\d+(\\.al\\d+)?|dotnet\\d+|dotnetcore\\d+\\.\\d+|ruby\\d+\\.\\d+|go\\d+\\.x|provided(\\.al\\d+)?)$", var.runtime))
+    error_message = "runtime must be a valid AWS Lambda runtime identifier (e.g. python3.13, nodejs22.x, java21, dotnet8, ruby3.3, provided.al2023, go1.x)."
+  }
 }
 
 variable "memory_size" {
   description = "Amount of memory in MB allocated for the Lambda function"
   type        = number
   default     = 128
+
+  validation {
+    condition     = var.memory_size >= 128 && var.memory_size <= 10240 && floor(var.memory_size) == var.memory_size
+    error_message = "memory_size must be a whole number between 128 and 10240 MB."
+  }
 }
 
 variable "architectures" {
   description = "Architectures supported by the Lambda function (e.g., x86_64, arm64)"
   type        = list(string)
   default     = ["x86_64"]
+
+  validation {
+    # AWS Lambda supports exactly one architecture per function.
+    condition     = length(var.architectures) == 1 && alltrue([for a in var.architectures : contains(["x86_64", "arm64"], a)])
+    error_message = "architectures must be exactly one of [\"x86_64\"] or [\"arm64\"]."
+  }
 }
 
 variable "timeout" {
   description = "Timeout in seconds before the Lambda function is terminated"
   type        = number
   default     = 3
+
+  validation {
+    condition     = var.timeout >= 1 && var.timeout <= 900 && floor(var.timeout) == var.timeout
+    error_message = "timeout must be a whole number of seconds between 1 and 900 (15 minutes)."
+  }
 }
 
 variable "publish" {
@@ -75,12 +101,25 @@ variable "layers" {
   description = "List of ARNs of Lambda layers to include"
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = alltrue([for l in var.layers : can(regex("^arn:aws[a-z-]*:lambda:[a-z0-9-]+:[0-9]{12}:layer:[a-zA-Z0-9-_]+:[0-9]+$", l))])
+    error_message = "layers must all be valid Lambda layer version ARNs (e.g. arn:aws:lambda:us-east-1:123456789012:layer:my-layer:1)."
+  }
 }
 
 variable "env_kms_key_arn" {
   description = "The ARN of the KMS key to be used for encrypting environment variables in the Lambda function"
   type        = string
   default     = null
+
+  validation {
+    # null = use the AWS-managed default key (the module passes this value
+    # straight through, so only null is the "unset" sentinel). Partition left
+    # open (aws / aws-us-gov / aws-cn); key/ allows the mrk- multi-region prefix.
+    condition     = var.env_kms_key_arn == null || can(regex("^arn:aws[a-z-]*:kms:[a-z0-9-]+:[0-9]{12}:(key/[0-9a-zA-Z-]+|alias/[a-zA-Z0-9/_-]+)$", var.env_kms_key_arn))
+    error_message = "env_kms_key_arn must be null or a valid KMS key or alias ARN (e.g. arn:aws:kms:us-east-1:123456789012:key/<id>)."
+  }
 }
 
 variable "environment_variables" {
@@ -99,6 +138,11 @@ variable "tracing_mode" {
   description = "Tracing mode for AWS X-Ray (e.g., PassThrough, Active)"
   type        = string
   default     = "PassThrough"
+
+  validation {
+    condition     = var.tracing_mode == null || contains(["PassThrough", "Active"], var.tracing_mode)
+    error_message = "tracing_mode must be either \"PassThrough\" or \"Active\"."
+  }
 }
 
 variable "vpc_subnet_ids" {
@@ -129,12 +173,27 @@ variable "cloudwatch_retention_in_days" {
   description = "Number of days to retain log events in the specified log group"
   type        = number
   default     = 30
+
+  validation {
+    condition = contains(
+      [0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653],
+      var.cloudwatch_retention_in_days
+    )
+    error_message = "cloudwatch_retention_in_days must be a valid CloudWatch Logs retention value (0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, or 3653). 0 means never expire."
+  }
 }
 
 variable "cloudwatch_kms_key_arn" {
   description = "KMS Key ARN to encrypt the CloudWatch Logs"
   type        = string
   default     = null
+
+  validation {
+    # null = no CMK (the module passes this straight through). Partition left
+    # open (aws / aws-us-gov / aws-cn); key/ allows the mrk- multi-region prefix.
+    condition     = var.cloudwatch_kms_key_arn == null || can(regex("^arn:aws[a-z-]*:kms:[a-z0-9-]+:[0-9]{12}:(key/[0-9a-zA-Z-]+|alias/[a-zA-Z0-9/_-]+)$", var.cloudwatch_kms_key_arn))
+    error_message = "cloudwatch_kms_key_arn must be null or a valid KMS key or alias ARN (e.g. arn:aws:kms:us-east-1:123456789012:key/<id>)."
+  }
 }
 
 variable "addl_policies" {


### PR DESCRIPTION
Closes #31.

Adds fail-fast variable validation — config mistakes now error at `terraform plan` with a clear message instead of as an opaque AWS API failure mid-`apply`.

## What's validated
| variable | rule |
|---|---|
| `runtime` | **shape** regex matching the identifier families (forward-compatible) |
| `memory_size` | whole number `128..10240` MB |
| `timeout` | whole number `1..900` s |
| `architectures` | exactly one of `["x86_64"]` / `["arm64"]` (Lambda allows one) |
| `layers` | each a valid Lambda layer version ARN |
| `tracing_mode` | `PassThrough` / `Active` (null-guarded) |
| `cloudwatch_retention_in_days` | valid CloudWatch retention enum (`0` = never) |
| `env_kms_key_arn`, `cloudwatch_kms_key_arn` | `null` or a KMS key/alias ARN |

## Deviations from the issue body (verified against AWS docs)
- **`runtime` is the big one.** The issue proposed a *version-locked* enum (`nodejs(18\|20\|22)`, `python3\.(8\|9\|10\|11\|12)`, `java(8\|11\|17\|21)`, …). That list is **already stale** — it rejects `nodejs24.x`, `python3.13`/`3.14`, `java25`, `dotnet9`/`10`, `ruby3.3`/`3.4`/`4.0`, all of which are valid runtimes **today**, and would reject every future one on launch day. I ship a **structural** regex that matches the identifier *families* (`nodejs\d+\.x`, `python\d+\.\d+`, `java\d+(\.al\d+)?`, `dotnet\d+`, `ruby\d+\.\d+`, `provided(\.al\d+)?`, …) — catches typos, survives next month's release. Verified against the live AWS runtime list.
- **KMS ARN regex**: the issue's `^arn:aws:kms:...key/[a-f0-9-]+$` was partition-locked (rejects gov/cn), key-ARN-only (rejects alias ARNs), and rejected `mrk-` multi-region keys. Fixed all three. `null` = use AWS-managed default (the module passes the value straight through, so `null` is the only unset sentinel — `""` is rejected, fail-fast).
- **`architectures`**: AWS supports exactly one architecture → validate length, not just membership.

## Testing
38 positive/negative cases, all green — incl. future runtimes (`python3.14`, `java25`, `dotnet10`, `ruby4.0`) accepted, typos rejected; memory/timeout bounds + non-integers; arch exactly-one; layer ARNs (gov partition); retention enum; KMS null/alias/mrk/junk. `terraform fmt` + full `validate` clean; README untouched (validation blocks don't render in terraform-docs).

@oldmanbendobot — third + last of the validation-rules sweep (apigateway#76 + tfstate#207 already merged). eyes when you've got a sec? ♡ 🐱