### PR TITLE
pr-label: consolidate onto the reusable workflow

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,3 +1,9 @@
+# Thin caller -> reusable pr-label in bendoerr-terraform-modules/workflows.
+# pr-label is the moving-@v1 lane (can't block a merge). Trigger stays local (can't live in a reusable
+# workflow). The job MUST grant pull-requests: write here: this repo's default_workflow_permissions is
+# `read` and a reusable workflow's permissions are CAPPED by the caller, so without this grant
+# actions/labeler gets a read-only token and 403s on applying labels SILENTLY (job goes green having
+# labeled nothing). labeler still reads this repo's own .github/labeler.yml (caller context).
 name: Label Pull Request
 
 on:
@@ -8,15 +14,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
-
     permissions:
       contents: read
       pull-requests: write
-
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 #v6.1.0
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/pr-label.yml@v1


### PR DESCRIPTION
@oldmanbendobot — kicking off the pr-label consolidation with lambda as the canary ♡

## what
Replaces this repo's **standalone** `pr-label.yml` with the **thin caller** of `workflows/.github/workflows/pr-label.yml@v1` — the exact pattern `terraform-module-repo-template` already rides (proven on template#97).

## why it's a true drop-in (behavior-preserving)
- the reusable's body is **byte-identical** to this repo's standalone: `harden-runner` (audit) + `actions/labeler@f27b608 v6.1.0`, same `contents:read` + `pull-requests:write`.
- `actions/labeler` reads `.github/labeler.yml` from the **caller** repo (`github.repository` resolves to the caller in a reusable workflow), so lambda's own label rules stay untouched.
- keeps the `pull-requests: write` grant on the job — without it the caller-capped token makes labeler **403 silently** (green job, zero labels). that's the one real footgun and it's covered.

## proof
pr-label isn't a required check and can go green having labeled nothing, so the bar isn't "green" — it's **labels actually applied**. this very PR triggers the new caller (`on: pull_request`, head version runs), so watch this PR get labeled per lambda's `labeler.yml`. i'll confirm on the run.

first of the 7 standalone repos (lambda, apigateway, cf-and-s3, jwt-authz, null-context, null-label, tflint-plugin). moving-`@v1` lane so no SHA churn. the 4 with no labeler at all (defaults, tfstate, tfuser, fargate) are a separate "do we want labeling there" question — not in this sweep.