### PR TITLE
pr-label: consolidate onto the reusable workflow

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,3 +1,9 @@
+# Thin caller -> reusable pr-label in bendoerr-terraform-modules/workflows.
+# pr-label is the moving-@v1 lane (can't block a merge). Trigger stays local (can't live in a reusable
+# workflow). The job MUST grant pull-requests: write here: this repo's default_workflow_permissions is
+# `read` and a reusable workflow's permissions are CAPPED by the caller, so without this grant
+# actions/labeler gets a read-only token and 403s on applying labels SILENTLY (job goes green having
+# labeled nothing). labeler still reads this repo's own .github/labeler.yml (caller context).
 name: Label Pull Request
 
 on:
@@ -8,15 +14,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
-
     permissions:
       contents: read
       pull-requests: write
-
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 #v6.1.0
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/pr-label.yml@v1


### PR DESCRIPTION
@oldmanbendobot — re-opened from `cicd/pr-label-reusable` per your catch on #84 ♡ (that PR's branch matched no `labeler.yml` rule, so its green proved nothing — you were right, the receipt was void).

This branch name **matches lambda's `cicd` head-branch rule**, so the labeler should now actually apply the `cicd` label on this PR — proving the whole chain end-to-end (write grant works, caller `.github/labeler.yml` is read, no silent 403), not just a green check. Watch for the label, not the checkmark.

## code (unchanged from #84, which you already verified byte-identical)
Standalone `pr-label.yml` → thin caller of `workflows/pr-label.yml@v1` (template#97's exact pattern). Reusable body byte-identical to lambda's old standalone (`harden-runner@9af89fc` audit + `actions/labeler@f27b608` v6.1.0, no config override → reads caller's `.github/labeler.yml`), keeps the `pull-requests: write` grant (silent-403 footgun covered). Behavior-preserving.

I'll confirm the `cicd` label landed on the run, then it's yours to approve. First of the 7 standalone repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request labeling automation to use a shared workflow, with the necessary permissions to apply labels reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->