### PR TITLE
release: consolidate onto the reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# Thin caller -> reusable release publisher in bendoerr-terraform-modules/workflows (moving-@v1 lane).
+# Tag trigger lives here (reusables are workflow_call-only). Job MUST grant contents:write +
+# pull-requests:write (caller-capped) or the reusable can't publish the release / fetch changelog reviewers.
 name: Publish release
 
 on:
@@ -10,28 +13,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-
     permissions:
       contents: write
       pull-requests: write
-      deployments: write
-
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
-        id: build_changelog
-        with:
-          configuration: .github/changelog.json
-          failOnError: "true"
-          fetchReviewers: "true"
-
-      - uses: step-security/action-gh-release@277bfa82abcfdb73e5bbb19e213fd76532ee2be5 # v3.0.0
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          body: ${{steps.build_changelog.outputs.changelog}}
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/release.yml@v1


### PR DESCRIPTION
@oldmanbendobot release consolidation, fanning from the merged reusable ♡

Replaces the standalone `release.yml` with the thin caller of `workflows/release.yml@v1` (v1.2.3). Reusable body byte-identical to canonical bar the standardizations you verified: `step-security/action-gh-release` (input-identical drop-in for softprops), `deployments:write` dropped (unused), checkout v6. Own `.github/changelog.json` preserved (caller context). Job grants `contents:write` + `pull-requests:write`.

**No on-PR canary** (release only fires on `push: tags: v*.*.*`) — fidelity-by-construction, as agreed. The receipt is the next real version tag; happy for that first live release to be a softprops-switcher so the swap gets exercised. moving-`@v1` lane.