### PR TITLE
feat: add permissions_boundary input for the execution role

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ will find a compatible version automatically.
 | <a name="input_layers"></a> [layers](#input_layers) | List of ARNs of Lambda layers to include | `list(string)` | `[]` | no |
 | <a name="input_memory_size"></a> [memory_size](#input_memory_size) | Amount of memory in MB allocated for the Lambda function | `number` | `128` | no |
 | <a name="input_name"></a> [name](#input_name) | A descriptive but short name used for labels by the 'bendoerr-terraform-modules/terraform-null-label' module. | `string` | `"thing"` | no |
+| <a name="input_permissions_boundary"></a> [permissions_boundary](#input_permissions_boundary) | ARN of the IAM policy to set as the permissions boundary on the Lambda's execution role. Null (the default) leaves the role unbounded. Set this to cap the role's effective permissions when a least-privilege deploy identity manages its inline policies. | `string` | `null` | no |
 | <a name="input_publish"></a> [publish](#input_publish) | Whether to publish a new version of the Lambda function | `bool` | `false` | no |
 | <a name="input_runtime"></a> [runtime](#input_runtime) | Runtime environment for the Lambda function (e.g., python3.9, nodejs14.x) | `string` | n/a | yes |
 | <a name="input_source_code_hash"></a> [source_code_hash](#input_source_code_hash) | Used to trigger updates when the content of the Lambda function changes (filebase64sha256 of the source code). If not provided, filebase64sha256(var.filename) will be used. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -96,9 +96,10 @@ data "aws_iam_policy_document" "assume_role_policy" {
 }
 
 resource "aws_iam_role" "this" {
-  name               = module.label.id
-  tags               = module.label.tags
-  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+  name                 = module.label.id
+  tags                 = module.label.tags
+  assume_role_policy   = data.aws_iam_policy_document.assume_role_policy.json
+  permissions_boundary = var.permissions_boundary
 }
 
 data "aws_iam_policy_document" "cloudwatch_logs" {

--- a/variables.tf
+++ b/variables.tf
@@ -272,6 +272,12 @@ variable "addl_inline_policies" {
   default     = {}
 }
 
+variable "permissions_boundary" {
+  description = "ARN of the IAM policy to set as the permissions boundary on the Lambda's execution role. Null (the default) leaves the role unbounded. Set this to cap the role's effective permissions when a least-privilege deploy identity manages its inline policies."
+  type        = string
+  default     = null
+}
+
 variable "source_code_hash" {
   description = "Used to trigger updates when the content of the Lambda function changes (filebase64sha256 of the source code). If not provided, filebase64sha256(var.filename) will be used."
   type        = string


### PR DESCRIPTION
## What

Adds an optional `permissions_boundary` input (ARN, default `null`) set on the module's `aws_iam_role.this`. `null` preserves current behavior — the role stays unbounded.

## Why

Part of a security fix in `bendobundles`: the least-privilege deploy role (`kitten-deploy`) manages the app lambdas' inline policies via `iam:PutRolePolicy`. That grant can only be safely *un-conditioned* if the target role carries a permissions boundary capping its effective permissions — otherwise the deploy identity could attach an over-broad policy and escalate (PutRolePolicy → `AdministratorAccess` on the exec role + its existing `UpdateFunctionCode` → account admin). This module gave no way to set that boundary, so the exec roles were uncapped and the deploy role's `PutRolePolicy` had to stay (non-functionally) boundary-conditioned. This input is the keystone that unblocks boundarying those roles.

## Change

- `variables.tf`: new `permissions_boundary` (string, default null).
- `main.tf`: `aws_iam_role.this.permissions_boundary = var.permissions_boundary` (+ alignment).
- `README.md`: one input row (hand-inserted in the repo's existing terraform-docs format — my local terraform-docs is a different version and would churn the whole doc; the `lint / terraform-docs` check will confirm).

`terraform fmt` + `validate` clean. Fully backward-compatible — existing callers get `null`.

@oldmanbendobot — your module, and this is the `permissions_boundary`-input follow-up we flagged when the deploy-role IAM landed (app roles fail-closed on full applies until this exists). Once this is tagged, bendobundles sets the boundary on the 3 exec roles, then the deploy-role statement splits. Ordering matters (boundary the roles *before* un-conditioning PutRolePolicy) — happy to walk the sequence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional permissions boundary setting for the Lambda execution role.
  * The new input is documented with its default value and behavior when left unset.

* **Documentation**
  * Updated the README to include the new input in the configuration table.

* **Style**
  * Cleaned up resource attribute formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->